### PR TITLE
Merge Tags from txt files with New Interrogations

### DIFF
--- a/tagger/settings.py
+++ b/tagger/settings.py
@@ -131,6 +131,16 @@ def on_ui_settings():
             section=section,
         ),
     )
+    
+    # merge interrogations from text files
+    shared.opts.add_option(
+        key='tagger_merge_existing_tags',
+        info=shared.OptionInfo(
+            False,
+            label='Merge with existing tags in text files before overwriting',
+            section=section,
+        ),
+    )
 
 
 def split_str(string: str, separator=',') -> List[str]:

--- a/tagger/ui.py
+++ b/tagger/ui.py
@@ -38,7 +38,9 @@ COMMON_OUTPUT = Tuple[
 ]
 
 class GalleryState:
-    selected_index: Optional[int] = None
+    """Tracks the state of the gallery across operations."""
+    last_update_source: str = None  # 'interrogation' or 'input_glob'
+    needs_update: bool = False
 
 def unload_interrogators() -> Tuple[str]:
     unloaded_models = 0
@@ -60,9 +62,12 @@ def unload_interrogators() -> Tuple[str]:
     return (f'{unloaded_models} model(s) unloaded{remaining_models}',)
 
 
-def on_interrogate(
-    input_glob: str, output_dir: str, name: str, filt: str, *args
-) -> COMMON_OUTPUT:
+def on_interrogate(input_glob: str, output_dir: str, name: str, filt: str, *args) -> COMMON_OUTPUT:
+    """Handler for interrogation."""
+    # Update gallery state
+    GalleryState.last_update_source = 'interrogation'
+    GalleryState.needs_update = True
+    
     # input glob should always be rechecked for new files
     IOData.update_input_glob(input_glob)
     if output_dir != It.input["output_dir"]:
@@ -87,10 +92,22 @@ def on_interrogate(
     return search_filter(filt)
 
 
-def on_gallery() -> List:
-    return QData.get_image_dups()
+def on_gallery(gallery) -> List[str]:
+    """Handler for gallery tab selection."""
+    print(f"Gallery tab selected, source is {GalleryState.last_update_source}")
+    
+    if GalleryState.last_update_source == "interrogation":
+        # Get image paths
+        if QData.json_db and QData.json_db.exists():
+            image_paths = get_image_paths()
+            print(f"Found {len(image_paths)} images for gallery")
+            return image_paths
+    if GalleryState.last_update_source == "input_glob":
+        return gallery
 
-
+    print("No db.json found")
+    return ""
+    
 def on_interrogate_image(*args) -> COMMON_OUTPUT:
     # hack brcause image interrogaion occurs twice
     It.odd_increment = It.odd_increment + 1
@@ -173,11 +190,161 @@ def search_filter(filt: str) -> COMMON_OUTPUT:
 
     return (', '.join(tags.keys()), h_tags, h_lost, ratings, tags, lost, info)
 
+def update_rating_tags_tab(rating_confidences, tag_confidences, discarded_tags):
+    """Updates the Ratings and included tags tab with data from QData."""
+    if not QData.weighed:
+        return
+        
+    # Get ratings and tags from QData.weighed
+    ratings = QData.weighed[0]  # ratings are in weighed[0]
+    tags = QData.weighed[1]     # tags are in weighed[1]
+    
+    # Update ratings display - calculate average weight per rating
+    rating_averages = {}
+    for rating, weights in ratings.items():
+        if weights:  # Only process if we have weights
+            rating_averages[rating] = sum(weight - int(weight) for weight in weights) / len(weights) * 100
+
+    rating_items = sorted(rating_averages.items(), key=lambda x: -x[1])
+    ratings_text = "\n".join([f"{k}: {v:.2f}%" for k, v in rating_items])
+    rating_confidences.update(value=ratings_text)
+    
+    # Update tags display - calculate average weight per tag
+    tag_averages = {}
+    for tag, weights in tags.items():
+        if weights:  # Only process if we have weights
+            tag_averages[tag] = sum(weight - int(weight) for weight in weights) / len(weights) * 100
+    
+    # Sort tags by their average weight
+    tag_items = sorted(tag_averages.items(), key=lambda x: -x[1])
+    
+    # Take top 100 tags (or adjust this number as needed. Note: higher numbers might hinder performance)
+    top_tags = tag_items[:100000]
+    tags_text = "\n".join([f"{k}: {v:.2f}%" for k, v in top_tags])
+    tag_confidences.update(value=tags_text)
+
+def get_image_paths() -> List[str]:
+    """Gets all image paths from IOData that have associated tags in QData."""
+    image_paths = []
+    
+    # Create a lookup dictionary for faster querying
+    query_lookup = {}
+    if QData.json_db and QData.json_db.exists():
+        try:
+            with open(QData.json_db, 'r') as f:
+                data = json.load(f)
+                query_lookup = {query_data[0]: query_data[1] 
+                              for query_data in data.get("query", {}).values()}
+        except (json.JSONDecodeError, AttributeError) as e:
+            print(f"Error reading db.json: {e}")
+            return image_paths
+    
+    # Process paths more efficiently
+    for path_info in IOData.paths:
+        image_path = str(path_info[0].absolute())
+        if image_path in query_lookup:
+            image_paths.append(image_path)
+            
+    return image_paths
+
+def on_input_glob_change(glob_path: str, rating_confidences, tag_confidences, discarded_tags, gallery, info):
+    """Handler for input glob changes."""
+    error_msg = ""
+    
+    # First update the input glob in IOData
+    IOData.update_input_glob(glob_path)
+    
+    # Update gallery state
+    GalleryState.last_update_source = 'input_glob'
+    GalleryState.needs_update = True
+    
+    # If db.json was loaded, update the UI components
+    if QData.json_db and QData.json_db.exists():
+        try:
+            # Calculate rating confidences
+            rating_dict = {}
+            for rating, weights in QData.weighed[0].items():
+                if weights:
+                    avg_weight = sum(weight - int(weight) for weight in weights) / len(weights)
+                    rating_dict[rating] = avg_weight
+            
+            # Calculate tag confidences and apply corrections
+            tag_dict = {}
+            excluded_dict = {}
+            for tag, weights in QData.weighed[1].items():
+                if weights:
+                    avg_weight = sum(weight - int(weight) for weight in weights) / len(weights)
+                    # Apply tag correction before checking exclusion
+                    corrected_tag = QData.correct_tag(tag)
+                    
+                    # Check if tag should be excluded based on QData criteria
+                    if QData.is_excluded(corrected_tag) or avg_weight < QData.threshold:
+                        excluded_dict[corrected_tag] = avg_weight
+                    else:
+                        tag_dict[corrected_tag] = avg_weight
+
+            # Sort tags by confidence
+            tag_items = sorted(tag_dict.items(), key=lambda x: -x[1])
+            excluded_items = sorted(excluded_dict.items(), key=lambda x: -x[1])
+
+            # Create clickable HTML tags
+            html_tags = []
+            for tag, conf in tag_items[:100000]:  # Limit to top 100 tags (or adjust this number as needed. Note: higher numbers might hinder performance)
+                html_tag = f'<a href="javascript:tag_clicked(\'{html_esc(tag)}\',true)">{tag}</a>'
+                html_tags.append(html_tag)
+            
+            html_excluded = []
+            for tag, conf in excluded_items[:100000]:  # Limit to top 100 tags (or adjust this number as needed. Note: higher numbers might hinder performance)
+                html_tag = f'<a href="javascript:tag_clicked(\'{html_esc(tag)}\',false)">{tag}</a>'
+                html_excluded.append(html_tag)
+
+            # Join tags with commas
+            tags_text = ', '.join(tag for tag, _ in tag_items[:100000]) # Limit to top 100 tags (or adjust this number as needed. Note: higher numbers might hinder performance)
+            html_tags_text = ', '.join(html_tags)
+            html_excluded_text = ', '.join(html_excluded)
+            
+            # Get all images with tags
+            gallery_images = get_image_paths()
+            print(f"Found {len(gallery_images)} images for gallery")
+            
+            if gallery_images:
+                # Update gallery with absolute paths
+                gallery.update(value=gallery_images)
+                
+                return (
+                    glob_path,                # input_glob
+                    tags_text,                # tags (plain text)
+                    html_tags_text,           # html_tags (clickable)
+                    html_excluded_text,       # discarded_tags (clickable)
+                    rating_dict,              # rating_confidences
+                    tag_dict,                 # tag_confidences
+                    excluded_dict,            # excluded_tag_confidences
+                    gallery_images,           # gallery images
+                    f"Found {len(gallery_images)} images for curation"
+                )
+            else:
+                print("No tagged images found")
+                return (
+                    glob_path, "", "", "", {}, {}, {},
+                    [],  # empty gallery
+                    "No tagged images found"
+                )
+            
+        except Exception as e:
+            error_msg = f"Error updating UI: {str(e)}"
+            print(f"Error in input_glob change handler: {error_msg}")
+            import traceback
+            traceback.print_exc()
+    
+    return glob_path, "", "", "", {}, {}, {}, [], error_msg or "No data found"
+
 def update_file_tags(file_path: str, selected_tags: List[str]) -> None:
     """Updates the tags file for a given image with the selected tags."""
     txt_path = Path(file_path).with_suffix('.txt')
     if txt_path.exists():
-        txt_path.write_text(', '.join(selected_tags), encoding='utf-8')
+        tag_string = ', '.join(tag.strip() for tag in selected_tags)
+        txt_path.write_text(tag_string, encoding='utf-8')
+        print(f"Updated {txt_path} with {len(selected_tags)} tags")
 
 def get_file_tags(file_path: str) -> List[str]:
     """Gets the existing tags from a file's associated txt file."""
@@ -188,7 +355,7 @@ def get_file_tags(file_path: str) -> List[str]:
     return []
 
 def parse_weight(weight_str: float) -> Tuple[int, float]:
-    """Parses a weight string into image_id and actual weight."""
+    """Parses a weight value into image_id and actual weight percentage."""
     image_id = int(weight_str)
     weight = weight_str - image_id
     return image_id, weight * 100  # Convert to percentage
@@ -217,59 +384,121 @@ def get_image_tags(image_id: int) -> Dict[str, float]:
         return {}
 
 def get_image_id_from_path(file_path: str) -> Optional[int]:
-    """Gets the image ID from the query section of db.json."""
-    if not QData.json_db or not QData.json_db.exists():
-        return None
+    """Gets the image ID from the query section of db.json using cached data."""
+    if not hasattr(get_image_id_from_path, 'query_cache'):
+        get_image_id_from_path.query_cache = {}
         
-    try:
-        data = json.loads(QData.json_db.read_text())
-        queries = data.get("query", {})
-        
-        # Search for the file path in queries
-        for _, query_data in queries.items():
-            if query_data[0] == str(Path(file_path).absolute()):
-                return query_data[1]
-        return None
-        
-    except (json.JSONDecodeError, AttributeError) as e:
-        print(f"Error reading db.json: {e}")
-        return None
+        if QData.json_db and QData.json_db.exists():
+            try:
+                with open(QData.json_db, 'r') as f:
+                    data = json.load(f)
+                    get_image_id_from_path.query_cache = {
+                        query_data[0]: query_data[1] 
+                        for query_data in data.get("query", {}).values()
+                    }
+            except (json.JSONDecodeError, AttributeError) as e:
+                print(f"Error initializing query cache: {e}")
+                return None
+    
+    absolute_path = str(Path(file_path).absolute())
+    return get_image_id_from_path.query_cache.get(absolute_path)
 
 def get_sorted_tags(file_path: str) -> List[str]:
-    """Gets all tags for an image, sorted by weight."""
+    """Gets all tags for an image, sorted by weight and including text file tags."""
+    # First get tags from the text file
+    file_tags = get_file_tags(file_path)
+    file_tags_set = set(file_tags)
+    
+    # Get tags from db.json
     image_id = get_image_id_from_path(file_path)
-    if image_id is None:
-        return []
+    db_tags = []
+    if image_id is not None:
+        image_tags = get_image_tags(image_id)
+        # Sort db tags by weight
+        db_tags = [
+            tag for tag, _ in sorted(
+                image_tags.items(),
+                key=lambda x: (-x[1], x[0])  # Sort by weight desc, then tag name asc
+            )
+        ]
+    
+    # Combine tags:
+    # 1. Start with tags from text file in their original order
+    result = file_tags[:]
+    # 2. Add tags from db.json that aren't in the text file
+    result.extend(tag for tag in db_tags if tag not in file_tags_set)
+    
+    return result
+
+def get_image_ratings(image_id: int) -> Dict[str, float]:
+    """ Gets rating confidences for a specific image from db.json. """
+    if not QData.json_db or not QData.json_db.exists():
+        return {}
+    
+    try:
+        data = json.loads(QData.json_db.read_text())
+        ratings_data = data.get("rating", {})
+        image_ratings = {}
         
-    # Get tags from db.json for this image
-    image_tags = get_image_tags(image_id)
+        for rating, weights in ratings_data.items():
+            for weight in weights:
+                parsed_id, parsed_weight = parse_weight(weight)
+                if parsed_id == image_id:
+                    # Store the raw confidence value
+                    image_ratings[rating] = parsed_weight
+        
+        return image_ratings
     
-    # Get tags from the txt file
-    file_tags = set(get_file_tags(file_path))
+    except (json.JSONDecodeError, AttributeError) as e:
+        print(f"Error reading db.json: {e}")
+        return {}
+
+def format_ratings(ratings: Dict[str, float]) -> gr.Label.update:
+    """Formats rating confidences to match the Tag Generation tab display format."""
+    if not ratings:
+        return gr.Label.update(value="No ratings available")
     
-    # Sort tags by weight
-    sorted_tags = sorted(
-        image_tags.items(),
-        key=lambda x: (-x[1], x[0])  # Sort by weight desc, then tag name asc
-    )
+    # Create formatted ratings dictionary with proper percentage calculations
+    formatted_ratings = {}
+    for rating, confidence in ratings.items():
+        # Remove 'rating:' prefix if present
+        label = rating.replace('rating:', '')
+        # Store the original confidence value without additional scaling
+        formatted_ratings[label] = confidence / 100
     
-    # First add tags that are in the txt file
-    result = [tag for tag in sorted_tags if tag[0] in file_tags]
+    # Sort ratings by confidence (highest first)
+    sorted_ratings = sorted(formatted_ratings.items(), key=lambda x: -x[1])
     
-    # Then add tags that are not in the txt file
-    result.extend(tag for tag in sorted_tags if tag[0] not in file_tags)
-    
-    return [tag[0] for tag in result]
+    # Create the label update dictionary with properly formatted values
+    return gr.Label.update(value={
+        k: round(v, 6) for k, v in sorted_ratings
+    })
 
 def on_gallery_select(evt: gr.SelectData, state: gr.State) -> tuple:
     """Handler for gallery selection event."""
-    image_paths = QData.get_image_dups()
+    image_paths = get_image_paths()
     if not image_paths or evt.index >= len(image_paths):
-        return gr.CheckboxGroup.update(choices=[], value=[], label="No image selected"), None
+        return (
+            gr.CheckboxGroup.update(choices=[], value=[], label="No image selected"),
+            gr.Label.update(value={}),
+            None
+        )
         
     selected_path = image_paths[evt.index]
     file_tags = get_file_tags(selected_path)
     all_tags = get_sorted_tags(selected_path)
+    
+    # Get and format rating confidences
+    image_id = get_image_id_from_path(selected_path)
+    ratings = {}
+    if image_id is not None:
+        ratings = get_image_ratings(image_id)
+        
+    rating_update = format_ratings(ratings)
+    
+    print(f"Selected image: {selected_path}")
+    print(f"Found {len(all_tags)} tags, {len(file_tags)} selected")
+    print(f"Ratings: {ratings}")
     
     return (
         gr.CheckboxGroup.update(
@@ -277,20 +506,73 @@ def on_gallery_select(evt: gr.SelectData, state: gr.State) -> tuple:
             value=file_tags,
             label=f"Tags for {Path(selected_path).name}"
         ),
+        rating_update,
         evt.index
     )
 
-def on_tags_change(selected_tags: List[str], state: gr.State) -> None:
-    """Handler for checkbox group changes."""
-    if state is None:
+def on_tags_change(selected_tags: List[str], selected_index: gr.State) -> None:
+    """Handler for checkbox group changes that updates the associated text file."""
+    if selected_index is None:
+        print("No image selected")
         return
         
-    image_paths = QData.get_image_dups()
-    if not image_paths or state >= len(image_paths):
+    image_paths = get_image_paths()
+    if not image_paths or selected_index >= len(image_paths):
+        print("Invalid image selection")
         return
         
-    selected_path = image_paths[state]
+    selected_path = image_paths[selected_index]
+    print(f"Updating tags for {selected_path}")
+    print(f"Selected tags: {len(selected_tags)}")
+    
+    # Update the text file with only the selected tags
     update_file_tags(selected_path, selected_tags)
+
+def add_new_tag(new_tag: str, selected_index: gr.State) -> tuple:
+    """Adds a new tag to the image's text file and refreshes the tag editor."""
+    if selected_index is None:
+        return (
+            gr.CheckboxGroup.update(choices=[], value=[]),
+            gr.Textbox.update(value="")
+        )
+    
+    image_paths = get_image_paths()
+    if not image_paths or selected_index >= len(image_paths):
+        return (
+            gr.CheckboxGroup.update(choices=[], value=[]),
+            gr.Textbox.update(value="")
+        )
+    
+    selected_path = image_paths[selected_index]
+    
+    # Get existing tags
+    current_tags = get_file_tags(selected_path)
+    
+    # Clean and validate the new tag
+    new_tag = new_tag.strip()
+    if not new_tag or new_tag in current_tags:
+        return (
+            gr.CheckboxGroup.update(choices=get_sorted_tags(selected_path), value=current_tags),
+            gr.Textbox.update(value="")
+        )
+    
+    # Add the new tag at the beginning of the list
+    current_tags.insert(0, new_tag)
+    
+    # Update the text file
+    update_file_tags(selected_path, current_tags)
+    
+    # Get fresh sorted tags
+    all_tags = get_sorted_tags(selected_path)
+    
+    return (
+        gr.CheckboxGroup.update(
+            choices=all_tags,
+            value=current_tags,
+            label=f"Tags for {Path(selected_path).name}"
+        ),
+        gr.Textbox.update(value="")  # Clear the textbox
+    )
 
 def create_gallery_ui(tab_gallery):
     """Creates the gallery UI components."""
@@ -308,7 +590,13 @@ def create_gallery_ui(tab_gallery):
                         elem_id='gallery',
                         object_fit="contain",
                         height="800px",
-                        show_label=False
+                        show_label=False,
+                        columns=4
+                    )
+                    rating_confidences = gr.Label(
+                        label="Rating Confidences",
+                        value={},
+                        elem_id="rating-confidences"
                     )
                 
                 # Right column with tag editor
@@ -321,18 +609,38 @@ def create_gallery_ui(tab_gallery):
                         container=True,
                         elem_id="tag-editor"
                     )
+                    with gr.Row():
+                        new_tag_input = gr.Textbox(
+                            label="Add New Tag",
+                            placeholder="Enter a new tag",
+                            show_label=True,
+                            container=True
+                        )
+                        add_tag_btn = gr.Button(
+                            value="+",
+                            variant="primary",
+                            elem_classes="tool"
+                        )
         
-        # Connect the components
         gallery.select(
             fn=on_gallery_select,
             inputs=[selected_index],
-            outputs=[tag_editor, selected_index]
+            outputs=[tag_editor, rating_confidences, selected_index]
         )
-        
         tag_editor.change(
             fn=on_tags_change,
             inputs=[tag_editor, selected_index],
             outputs=[]
+        )
+        add_tag_btn.click(
+            fn=add_new_tag,
+            inputs=[new_tag_input, selected_index],
+            outputs=[tag_editor, new_tag_input]
+        )
+        new_tag_input.submit(
+            fn=add_new_tag,
+            inputs=[new_tag_input, selected_index],
+            outputs=[tag_editor, new_tag_input]
         )
         
         return gallery
@@ -479,9 +787,15 @@ def on_ui_tabs():
                             with gr.Row(variant='compact'):
                                 cumulative = utils.preset.component(
                                     gr.Checkbox,
-                                    label='Combine interrogations',
+                                    label='Combine interrogations from memory',
                                     value=False
                                 )
+                                merge_existing = utils.preset.component(
+                                    gr.Checkbox,
+                                    label='Merge interrogation with existing tags',
+                                    value=False
+                                )
+                                
                                 unload_after = utils.preset.component(
                                     gr.Checkbox,
                                     label='Unload model after running',
@@ -570,6 +884,11 @@ def on_ui_tabs():
         # register events
         # Checkboxes
         cumulative.input(fn=It.flip('cumulative'), inputs=[], outputs=[])
+        merge_existing.input(
+            fn=lambda x: setattr(QData, 'merge_existing', x),
+            inputs=[merge_existing],
+            outputs=[]
+        )
         large_query.input(fn=It.flip('large_query'), inputs=[], outputs=[])
         unload_after.input(fn=It.flip('unload_after'), inputs=[], outputs=[])
 
@@ -600,13 +919,40 @@ def on_ui_tabs():
             tag_input[tag].blur(fn=wrap_gradio_gpu_call(It.set(tag)),
                                 inputs=[tag_input[tag]],
                                 outputs=[tag_input[tag], info])
-
-        input_glob.blur(fn=wrap_gradio_gpu_call(It.set("input_glob")),
-                        inputs=[input_glob], outputs=[input_glob, info])
+        
+        # Update UI tabs for input_glob change
+        input_glob.blur(
+            fn=wrap_gradio_gpu_call(
+                lambda x: on_input_glob_change(
+                    x,
+                    rating_confidences,
+                    tag_confidences, 
+                    discarded_tags,
+                    gallery,
+                    info
+                )
+            ),
+            inputs=[input_glob],
+            outputs=[
+                input_glob,
+                tags,               # Plain text tags
+                html_tags,          # HTML formatted clickable tags
+                discarded_tags,     # HTML formatted clickable excluded tags
+                rating_confidences, # Rating confidences dict
+                tag_confidences,    # Tag confidences dict
+                excluded_tag_confidences, # Excluded tag confidences dict
+                gallery,            # Gallery component
+                info
+            ]
+        )
         output_dir.blur(fn=wrap_gradio_gpu_call(It.set("output_dir")),
                         inputs=[output_dir], outputs=[output_dir, info])
 
-        tab_gallery.select(fn=on_gallery, inputs=[], outputs=[gallery])
+        tab_gallery.select(
+            fn=on_gallery,
+            inputs=[gallery],
+            outputs=[gallery]
+        )
 
         common_output = [tags, html_tags, discarded_tags, rating_confidences,
                          tag_confidences, excluded_tag_confidences, info]

--- a/tagger/uiset.py
+++ b/tagger/uiset.py
@@ -192,6 +192,22 @@ class IOData:
                         cls.err.add(msg)
                 else:
                     cls.paths.append([path, tags_out, output_dir])
+                    
+    @classmethod
+    def read_existing_tags(cls, file_path):
+        """Read existing tags from a text file if it exists"""
+        if not os.path.exists(file_path):
+            return []
+            
+        try:
+            with open(file_path, 'r', encoding='utf-8') as f:
+                content = f.read().strip()
+                if not content:
+                    return []
+                return [tag.strip() for tag in content.split(',')]
+        except Exception as e:
+            print(f"Error reading tags from {file_path}: {e}")
+            return []
 
 
 class QData:
@@ -204,6 +220,7 @@ class QData:
     threshold = 0.35
     tag_frac_threshold = 0.05
     count_threshold = getattr(shared.opts, 'tagger_count_threshold', 100)
+    merge_existing = False
 
     # read from db.json, update with what should be written to db.json:
     json_db = None
@@ -399,32 +416,45 @@ class QData:
                 cls.had_new = False
                 msg = f'Error reading {cls.json_db}'
                 cls.err.discard(msg)
-                # validate json using either json_schema/db_jon_v1_schema.json
-                # or json_schema/db_jon_v2_schema.json
 
-                schema = Path(__file__).parent.parent.joinpath(
-                    'json_schema', 'db_json_v1_schema.json'
-                )
                 try:
                     data = loads(cls.json_db.read_text())
+                    
+                    # Validate schema
+                    schema = Path(__file__).parent.parent.joinpath(
+                        'json_schema', 'db_json_v1_schema.json'
+                    )
                     validate(data, loads(schema.read_text()))
 
-                    # convert v2 back to v1
-                    if "meta" in data:
-                        cls.had_new = True  # <- force write for v2 -> v1
+                    # Update class data
+                    cls.query = data["query"]
+                    cls.weighed = (
+                        defaultdict(list, data["rating"]),
+                        defaultdict(list, data["tag"])
+                    )
+                    
+                    # Initialize cls.tags with average weights from weighed data
+                    cls.tags.clear()
+                    for tag, weights in cls.weighed[1].items():
+                        if weights:  # Only process if we have weights
+                            # Calculate average weight by taking fractional part of each weight
+                            avg_weight = sum(weight - int(weight) for weight in weights) / len(weights)
+                            cls.tags[tag] = avg_weight
+
+                    print(f'Read {cls.json_db}: {len(cls.query)} interrogations, '
+                          f'{len(cls.tags)} tags.')
+
                 except (ValidationError, IndexError) as err:
                     print(f'{msg}: {repr(err)}')
                     cls.err.add(msg)
                     data = {"query": {}, "tag": [], "rating": []}
-
-                cls.query = data["query"]
-                cls.weighed = (
-                    defaultdict(list, data["rating"]),
-                    defaultdict(list, data["tag"])
-                )
-                print(f'Read {cls.json_db}: {len(cls.query)} interrogations, '
-                      f'{len(cls.tags)} tags.')
-
+                    cls.query = data["query"]
+                    cls.weighed = (
+                        defaultdict(list, data["rating"]),
+                        defaultdict(list, data["tag"])
+                    )
+                    cls.tags.clear()
+                
     @classmethod
     def write_json(cls) -> None:
         """ write db.json """
@@ -617,9 +647,21 @@ class QData:
         for ent, val in cls.ratings.items():
             ratings[ent] = val / count
 
-        weighted_tags_files = getattr(shared.opts,
-                                      'tagger_weighted_tags_files', False)
+        weighted_tags_files = getattr(shared.opts, 'tagger_weighted_tags_files', False)
+        merge_existing = getattr(shared.opts, 'tagger_merge_existing_tags', False)
+
         for file, remaining_tags in cls.for_tags_file.items():
+            # If merge_existing is True, read existing tags
+            existing_tags = []
+            if cls.merge_existing and os.path.exists(file):
+                existing_tags = IOData.read_existing_tags(file)
+                existing_tags_set = set(existing_tags)
+                
+                # Add existing tags that aren't already in the remaining_tags
+                for tag in existing_tags:
+                    if tag not in remaining_tags:
+                        remaining_tags[tag] = 1.0  # Give existing tags maximum confidence
+                        
             sorted_tags = cls.sort_tags(remaining_tags)
             if weighted_tags_files:
                 sorted_tags = [f'({k}:{v})' for k, v in sorted_tags]


### PR DESCRIPTION
This adds a new option to `Merge interrogation with existing tags` from the generated txt files, instead of just from interrogation memory. This is helpful in the cases where tags were added to the txt file manually and an new interrogation was run afterwards overwriting the manually added tags, requiring manually added tags to be re-added. These cases would happen when using the `Tag Curator`. This patch will not prevent manually removed tags from being re-added to the txt file by the tagger during a new interrogation.

### Changes:

1. **Adds a new setting** in the settings backend that persists the user's preference for merging tags (`settings.py`)
2. Adds a helper function to `IOData` in `uiset.py` to **read existing tags from files** (`uiset.py`)
3. **Modifies** `QData.finalize_batch` and `finalize` methods which handles the **tag writing process** to:

   1. Check if the merge option is enabled
   2. Read existing tags from the text file if it exists
   3. Add those tags to the set of tags being written
   4. Give existing tags maximum confidence to ensure they're kept

4. **Updates the UI to include a new toggle** between to the existing "Combine interrogations" and "Unload model after running" toggles (`ui.py`)

   - Existing "Combine interrogations" has been changed to "Combine interrogations from memory"

### New Behavior:

1. Check if a tag file already exists before writing
2. If it exists, read the existing tags
3. Add any missing tags to the new set with maximum confidence
4. Write the combined set back to the file